### PR TITLE
Fixes package metadata to point to correct repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TylorS/most-proxy.git"
+    "url": "git+https://github.com/cyclejs/most-run.git"
   },
   "keywords": [
     "Cycle",
@@ -42,9 +42,9 @@
   "author": "Tylor Steinberger <tlsteinberger167@gmail.com> (github.com/TylorS)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/TylorS/most-proxy/issues"
+    "url": "https://github.com/cyclejs/most-run/issues"
   },
-  "homepage": "https://github.com/TylorS/most-proxy#readme",
+  "homepage": "https://github.com/cyclejs/most-run#readme",
   "devDependencies": {
     "babel-plugin-espower": "^2.1.2",
     "babel-preset-es2015": "^6.9.0",


### PR DESCRIPTION
Fixes issue introduced in 083d6088bbeb0cf333e166fa561036ca0faa1c62 where git repo and URLs were changed to github.com/TylorS/most-proxy
